### PR TITLE
Updated gradle to version 2.4 and maven URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 			url = "https://oss.sonatype.org/content/repositories/snapshots/"
 		}
 		maven {
-			url 'http://maven.magik6k.net/'
+			url 'http://maven.novaapi.net/'
 		}
 	}
 	dependencies {
@@ -48,7 +48,7 @@ repositories {
 	mavenCentral()
 	mavenLocal()
 	maven {
-		url 'http://maven.magik6k.net/'
+		url 'http://maven.novaapi.net/'
 	}
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip


### PR DESCRIPTION
Updated gradle to version 2.4 and maven URL from maven.magik6k.net to maven.novaapi.net.
